### PR TITLE
test: enable fulu hf at epoch one

### DIFF
--- a/.github/tests/custom-fulu.yaml
+++ b/.github/tests/custom-fulu.yaml
@@ -50,4 +50,4 @@ ethereum_package:
     capella_fork_epoch: 0
     deneb_fork_epoch: 0
     electra_fork_epoch: 0
-    fulu_fork_epoch: 0
+    fulu_fork_epoch: 1 # blocks are not finalized if fulu hard fork is activated at genesis

--- a/.github/tests/custom-fulu.yaml
+++ b/.github/tests/custom-fulu.yaml
@@ -50,4 +50,4 @@ ethereum_package:
     capella_fork_epoch: 0
     deneb_fork_epoch: 0
     electra_fork_epoch: 0
-    fulu_fork_epoch: 3 # enabling the fulu hard fork before would result in the op-chain deployment tx (26193342 gas) being reverted because it exceeds the tx gas limit (16777216 gas) set by the fulu hard fork; setting it to 3 means the fulu hard fork will be activated after 3*8*2=48 seconds (3 epochs of 8 slots of 2 seconds each in the case of the minimal preset), which should be enough time for the op-chain to be deployed.
+    fulu_fork_epoch: 0


### PR DESCRIPTION
- Attempt to enable the fulu hardfork at genesis since the new op-deployer `v0.4.3` should fix the issue we faced with the op-chain deployment tx (26193342 gas) being reverted because it exceeds the tx gas limit (16777216 gas) set by the fulu hf.
- It turns out enabling the hf at genesis doesn't work since blocks are not getting finalized: https://github.com/agglayer/optimism-package/actions/runs/18368668145/job/52326542686
- Trying with enabling the hf at epoch 1 instead.