### PR TITLE
fix: op-node version check to allow custom build

### DIFF
--- a/FORK.md
+++ b/FORK.md
@@ -16,6 +16,7 @@
 
 | # | Title | Scope | Notes |
 |---|-------|-------|-------|
+| 12 | fix: op-node version check to allow custom build | op-node | Fix op-node version check to allow custom builds based on v1.14.1 | 
 | 11 | fix: enable block finalization for fusaka env | ci, fusaka hf | Enable block finalization for fusaka environment and add additional checks in ci to ensure safe and finalized blocks are progressing |
 | 10 | feat: upgrade contracts and tooling, fix service naming and metric, support for fusaka hf | contracts, op-deployer, el/cl clients, op-batcher, op-proposer, proxyd, tests, ci, fusaka hf | Upgrade op-deployer and contract versions, fix service naming (el/cl clients, op-batcher, op-proposer and proxyd), disable metrics registration, and add support and test configs for Fusaka hardfork |
 | 09 | docs: document patches | docs | Add `FORK.md` to track fork policy and patches |

--- a/src/cl/op-node/launcher.star
+++ b/src/cl/op-node/launcher.star
@@ -222,7 +222,8 @@ def get_service_config(
     if len(op_node_version) != 2:
         fail("Could not parse op-node version from image: {}".format(params.image))
 
-    if op_node_version[1] in ["v1.14.1"]:
+    op_node_version_formatted = op_node_version[1].split("-")[0] # remove any suffixes like -rc0, -beta, -custom etc.
+    if op_node_version_formatted in ["1.14.1"]:
         l1_genesis_original = plan.get_files_artifact(name="el_cl_genesis_data")
         result = plan.run_sh(
             description="Standardize L1 genesis for op-node",

--- a/src/cl/op-node/launcher.star
+++ b/src/cl/op-node/launcher.star
@@ -222,7 +222,9 @@ def get_service_config(
     if len(op_node_version) != 2:
         fail("Could not parse op-node version from image: {}".format(params.image))
 
-    op_node_version_formatted = op_node_version[1].split("-")[0] # remove any suffixes like -rc0, -beta, -custom etc.
+    op_node_version_formatted = op_node_version[1].split("-")[
+        0
+    ]  # remove any suffixes like -rc0, -beta, -custom etc.
     if op_node_version_formatted in ["1.14.1"]:
         l1_genesis_original = plan.get_files_artifact(name="el_cl_genesis_data")
         result = plan.run_sh(


### PR DESCRIPTION
We rely on a custom version of the op-node to prevent it from connecting to mainnet nodes during startup. The resulting image, called `op-node:v1.14.1-custom`, does not work well with the OP package because the package skips providing the EL genesis to the CL node due to an overly strict version check. This PR fixes that issue.