### PR TITLE
ci: bump versions in custom configs

### DIFF
--- a/.github/tests/custom-antithesis.yaml
+++ b/.github/tests/custom-antithesis.yaml
@@ -17,7 +17,7 @@ optimism_package:
           - "--txmgr.enable-cell-proofs"
         max_channel_duration: 10
   op_contract_deployer_params:
-    image: europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/op-deployer:v5.0.0-rc.2-cdk
+    image: europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/op-deployer:v0.5.0-rc.2-cdk
     l1_artifacts_locator: embedded
     l2_artifacts_locator: embedded
   observability:

--- a/.github/tests/custom-antithesis.yaml
+++ b/.github/tests/custom-antithesis.yaml
@@ -1,21 +1,23 @@
 optimism_package:
   chains:
-    001:
+    "001":
       participants:
-        node1:
+        "node1":
           el:
             type: op-geth
-            image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101603.1
+            image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101603.4
           cl:
             type: op-node
-            image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.14.1-custom
+            image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.16.1-custom
             extra_params:
               - "--rollup.l1-chain-config=/l1/genesis.json"
       batcher_params:
-        image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-batcher:v1.16.0
+        image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-batcher:v1.16.2
+        extra_params:
+          - "--txmgr.enable-cell-proofs"
         max_channel_duration: 10
   op_contract_deployer_params:
-    image: europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/op-deployer:v0.4.3-cdk
+    image: europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/op-deployer:v5.0.0-rc.2-cdk
     l1_artifacts_locator: embedded
     l2_artifacts_locator: embedded
   observability:
@@ -24,9 +26,9 @@ optimism_package:
 ethereum_package:
   participants:
     - el_type: geth
-      el_image: ethereum/client-go:v1.16.4
+      el_image: ethereum/client-go:v1.16.7
       cl_type: lighthouse
-      cl_image: sigp/lighthouse:v8.0.0-rc.0
+      cl_image: sigp/lighthouse:v8.0.0
       supernode: true # required for fulu hf if perfect peerDAS is not enabled
   network_params:
     preset: minimal

--- a/.github/tests/custom-fulu.yaml
+++ b/.github/tests/custom-fulu.yaml
@@ -17,7 +17,7 @@ optimism_package:
           - "--txmgr.enable-cell-proofs"
         max_channel_duration: 10
   op_contract_deployer_params:
-    image: europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/op-deployer:v5.0.0-rc.2-cdk
+    image: europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/op-deployer:v0.5.0-rc.2-cdk
     l1_artifacts_locator: embedded
     l2_artifacts_locator: embedded
   observability:

--- a/.github/tests/custom-fulu.yaml
+++ b/.github/tests/custom-fulu.yaml
@@ -1,23 +1,23 @@
 optimism_package:
   chains:
-    001:
+    "001":
       participants:
-        node1:
+        "node1":
           el:
             type: op-geth
-            image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101603.1
+            image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101603.4
           cl:
             type: op-node
-            image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.14.1
+            image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.16.1
             extra_params:
               - "--rollup.l1-chain-config=/l1/genesis.json"
       batcher_params:
-        image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-batcher:v1.16.0
+        image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-batcher:v1.16.2
         extra_params:
           - "--txmgr.enable-cell-proofs"
         max_channel_duration: 10
   op_contract_deployer_params:
-    image: europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/op-deployer:v0.4.3-cdk
+    image: europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/op-deployer:v5.0.0-rc.2-cdk
     l1_artifacts_locator: embedded
     l2_artifacts_locator: embedded
   observability:
@@ -26,9 +26,9 @@ optimism_package:
 ethereum_package:
   participants:
     - el_type: geth
-      el_image: ethereum/client-go:v1.16.4
+      el_image: ethereum/client-go:v1.16.7
       cl_type: lighthouse
-      cl_image: sigp/lighthouse:v8.0.0-rc.0
+      cl_image: sigp/lighthouse:v8.0.0
       supernode: true # required for fulu hf if perfect peerDAS is not enabled
   network_params:
     preset: minimal

--- a/.github/tests/custom.yaml
+++ b/.github/tests/custom.yaml
@@ -10,8 +10,8 @@ optimism_package:
       batcher_params:
         max_channel_duration: 10
   op_contract_deployer_params:
-    image: europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/op-deployer:v0.4.2-cdk
-    l1_artifacts_locator: tag://op-contracts/v4.0.0
-    l2_artifacts_locator: tag://op-contracts/v4.0.0
+    image: europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/op-deployer:v5.0.0-rc.2-cdk
+    l1_artifacts_locator: embedded
+    l2_artifacts_locator: embedded
   observability:
     enabled: false

--- a/.github/tests/custom.yaml
+++ b/.github/tests/custom.yaml
@@ -10,7 +10,7 @@ optimism_package:
       batcher_params:
         max_channel_duration: 10
   op_contract_deployer_params:
-    image: europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/op-deployer:v5.0.0-rc.2-cdk
+    image: europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/op-deployer:v0.5.0-rc.2-cdk
     l1_artifacts_locator: embedded
     l2_artifacts_locator: embedded
   observability:

--- a/network_params.yaml
+++ b/network_params.yaml
@@ -54,7 +54,7 @@ optimism_package:
         enabled: true
   op_contract_deployer_params:
     # image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-deployer:v5.0.0-rc.2
-    image: europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/op-deployer:v5.0.0-rc.2-cdk
+    image: europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/op-deployer:v0.5.0-rc.2-cdk
     l1_artifacts_locator: tag://op-contracts/v5.0.0-rc.2
     l2_artifacts_locator: tag://op-contracts/v5.0.0-rc.2
   global_log_level: "info"

--- a/network_params.yaml
+++ b/network_params.yaml
@@ -53,10 +53,10 @@ optimism_package:
       tx_fuzzer_params:
         enabled: true
   op_contract_deployer_params:
-    # image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-deployer:v0.4.2
-    image: europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/op-deployer:v0.4.2-cdk
-    l1_artifacts_locator: tag://op-contracts/v4.0.0
-    l2_artifacts_locator: tag://op-contracts/v4.0.0
+    # image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-deployer:v5.0.0-rc.2
+    image: europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/op-deployer:v5.0.0-rc.2-cdk
+    l1_artifacts_locator: tag://op-contracts/v5.0.0-rc.2
+    l2_artifacts_locator: tag://op-contracts/v5.0.0-rc.2
   global_log_level: "info"
   global_node_selectors: {}
   global_tolerations: []


### PR DESCRIPTION
- l2 components: op-geth, op-node, op-batcher and op-deployer
- l1 components: geth and lighthouse