### PR TITLE
chore: bump versions and switch to op-reth in custom.yaml

### DIFF
--- a/.github/tests/custom.yaml
+++ b/.github/tests/custom.yaml
@@ -4,7 +4,7 @@ optimism_package:
       participants:
         "node1":
           el:
-            type: op-geth
+            type: op-reth
           cl:
             type: op-node
       batcher_params:
@@ -13,9 +13,9 @@ optimism_package:
 ethereum_package:
   participants:
     - el_type: geth
-      el_image: ethereum/client-go:v1.16.7
+      el_image: ethereum/client-go:v1.17.1
       cl_type: lighthouse
-      cl_image: sigp/lighthouse:v8.0.1
+      cl_image: sigp/lighthouse:v8.1.1
       supernode: true # required for fulu hf if perfect peerDAS is not enabled
   network_params:
     preset: minimal

--- a/FORK.md
+++ b/FORK.md
@@ -1,11 +1,13 @@
 # FORK
 
 ## Upstream
-- Repository: https://github.com/ethpandaops/optimism-package
+
+- Repository: <https://github.com/ethpandaops/optimism-package>
 - Base: `upstream/main`
 - Current sync point: [7bef190](https://github.com/ethpandaops/optimism-package/commit/7bef190d7c0b9f619438ed08b17bd5e5f51e72ff)
 
 ## Policy
+
 - [`main`](https://github.com/agglayer/optimism-package/tree/main): Tracks `upstream/main` exactly, without modifications.
 - [`overlay/main`](https://github.com/agglayer/optimism-package/tree/overlay/main): Contains our patch stack on top of `upstream/main` — this is where all fork-specific changes live.
 
@@ -16,17 +18,18 @@
 
 | # | Title | Scope | Notes |
 |---|-------|-------|-------|
+| 18 | chore: bump versions and switch to op-reth in custom.yaml | el clients, ci | Bump versions and switch to op-reth in custom.yaml |
 | 17 | chore: bump kurtosis and op components versions | ci | Bump kurtosis and op components versions |
 | 16 | chore: bump op-deployer to v5 | op-deployer | Bump op-deployer and contracts to v5 |
 | 15 | fix: op-node l1 genesis logic and bump custom configs | ci | Fix op-node L1 genesis logic and bump custom configs |
 | 14 | fix: enable cell proofs on op-batcher | fusaka hf | Enable cell proofs on op-batcher for fusaka hardfork |
 | 13 | fix: typo in op-node version check and add antithesis-like test config | op-node, ci, antithesis | Fix typo |
-| 12 | fix: op-node version check to allow custom build | op-node | Fix op-node version check to allow custom builds based on v1.14.1 | 
+| 12 | fix: op-node version check to allow custom build | op-node | Fix op-node version check to allow custom builds based on v1.14.1 |
 | 11 | fix: enable block finalization for fusaka env | ci, fusaka hf | Enable block finalization for fusaka environment and add additional checks in ci to ensure safe and finalized blocks are progressing |
 | 10 | feat: upgrade contracts and tooling, fix service naming and metric, support for fusaka hf | contracts, op-deployer, el/cl clients, op-batcher, op-proposer, proxyd, tests, ci, fusaka hf | Upgrade op-deployer and contract versions, fix service naming (el/cl clients, op-batcher, op-proposer and proxyd), disable metrics registration, and add support and test configs for Fusaka hardfork |
 | 09 | docs: document patches | docs | Add `FORK.md` to track fork policy and patches |
 | 08 | revert: el/cl client naming | el/cl clients | Revert client renaming to avoid updating references across [kurtosis-cdk](https://github.com/0xPolygon/kurtosis-cdk), [e2e](https://github.com/agglayer/e2e), and other repositories |
-| 07 | fix: ci jobs issues with op-deployer and `predeployed_allocs.json` | op-deployer, ci | Fix default configuration, test configs, and ci workflows related to op-deployer pre-deployed allocs | 
+| 07 | fix: ci jobs issues with op-deployer and `predeployed_allocs.json` | op-deployer, ci | Fix default configuration, test configs, and ci workflows related to op-deployer pre-deployed allocs |
 | 06 | feat: allow to disable proposer | op-proposer | Add ability to disable the op-proposer component |
 | 05 | feat: pre-deployed allocs for deployer | op-deployer | Enable passing predeployed files (e.g. `predeployed-allocs.json`) to the op-deployer (*) |
 | 04 | feat(op-batcher): max channel duration | op-batcher | Allow customization of the op-batcher’s maximum channel duration |

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ optimism_package:
 
             # The Docker image that should be used for the EL client; leave blank to use the default for the client type
             # Defaults by client:
-            # - op-geth: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101604.0
+            # - op-geth: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101609.1
             # - op-reth: parithoshj/op-reth:latest
             # - op-erigon: testinprod/op-erigon:v2.61.3-0.9.5
             # - op-nethermind: nethermindeth/nethermind:op-c482d56
@@ -282,7 +282,7 @@ optimism_package:
 
             # The Docker image that should be used for the CL client; leave blank to use the default for the client type
             # Defaults by client:
-            # - op-node: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.16.4
+            # - op-node: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.16.7
             # - hildr: ghcr.io/optimism-java/hildr:v0.4.5
             image: ""
 
@@ -345,7 +345,7 @@ optimism_package:
 
             # The Docker image that should be used for the builder EL client; leave blank to use the default for the client type
             # Defaults by client:
-            # - op-geth: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101604.0
+            # - op-geth: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101609.1
             # - op-reth: parithoshj/op-reth:latest
             # - op-rbuilder: ghcr.io/flashbots/op-rbuilder:0.1.2-interop
             image: ""
@@ -363,7 +363,7 @@ optimism_package:
 
             # The Docker image that should be used for the builder CL client; leave blank to use the default for the client type
             # Defaults by client:
-            # - op-node: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.16.4
+            # - op-node: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.16.7
             # - hildr: ghcr.io/optimism-java/hildr:v0.4.5
             image: ""
 

--- a/kurtosis.yml
+++ b/kurtosis.yml
@@ -3,6 +3,6 @@ description: |
   # Optimism Package
   This is a Kurtosis package for deploying an Optimism Rollup
 replace:
-  github.com/ethpandaops/ethereum-package: github.com/ethpandaops/ethereum-package@eb8c590a3634188ecb29ae1319ee53bd356e16e7
+  github.com/ethpandaops/ethereum-package: github.com/ethpandaops/ethereum-package@343ae7f946408cde2950241bb3239d4810acc306 # 2026-03-03
   github.com/kurtosis-tech/prometheus-package: github.com/kurtosis-tech/prometheus-package@f5ce159aec728898e3deb827f6b921f8ecfc527f
   github.com/kurtosis-tech/postgres-package: github.com/kurtosis-tech/postgres-package@2d363be1bc42524f6b0575cac0bbc0fd194ae173

--- a/kurtosis.yml
+++ b/kurtosis.yml
@@ -3,6 +3,6 @@ description: |
   # Optimism Package
   This is a Kurtosis package for deploying an Optimism Rollup
 replace:
-  github.com/ethpandaops/ethereum-package: github.com/ethpandaops/ethereum-package@094b3f3da003ae91cd83c0517deccec4c0f73425
+  github.com/ethpandaops/ethereum-package: github.com/ethpandaops/ethereum-package@eb8c590a3634188ecb29ae1319ee53bd356e16e7
   github.com/kurtosis-tech/prometheus-package: github.com/kurtosis-tech/prometheus-package@f5ce159aec728898e3deb827f6b921f8ecfc527f
   github.com/kurtosis-tech/postgres-package: github.com/kurtosis-tech/postgres-package@2d363be1bc42524f6b0575cac0bbc0fd194ae173

--- a/mise.toml
+++ b/mise.toml
@@ -2,7 +2,7 @@
 
 # Core dependencies
 just = "1.40.0"
-"ubi:leovct/kurtosis-test" = "v0.0.7"
+"ubi:leovct/kurtosis-test" = "v0.0.8"
 "ubi:kurtosis-tech/kurtosis-cli-release-artifacts[exe=kurtosis]" = "1.16.5"
 "yq" = "v4.44.3"
 

--- a/mise.toml
+++ b/mise.toml
@@ -3,7 +3,7 @@
 # Core dependencies
 just = "1.40.0"
 "ubi:leovct/kurtosis-test" = "v0.0.8"
-"ubi:kurtosis-tech/kurtosis-cli-release-artifacts[exe=kurtosis]" = "1.16.5"
+"ubi:kurtosis-tech/kurtosis-cli-release-artifacts[exe=kurtosis]" = "1.16.4"
 "yq" = "v4.44.3"
 
 # lint

--- a/mise.toml
+++ b/mise.toml
@@ -3,7 +3,7 @@
 # Core dependencies
 just = "1.40.0"
 "ubi:leovct/kurtosis-test" = "v0.0.7"
-"ubi:kurtosis-tech/kurtosis-cli-release-artifacts[exe=kurtosis]" = "1.15.2"
+"ubi:kurtosis-tech/kurtosis-cli-release-artifacts[exe=kurtosis]" = "1.16.5"
 "yq" = "v4.44.3"
 
 # lint

--- a/mise.toml
+++ b/mise.toml
@@ -3,7 +3,7 @@
 # Core dependencies
 just = "1.40.0"
 "ubi:leovct/kurtosis-test" = "v0.0.7"
-"ubi:kurtosis-tech/kurtosis-cli-release-artifacts[exe=kurtosis]" = "1.14.1"
+"ubi:kurtosis-tech/kurtosis-cli-release-artifacts[exe=kurtosis]" = "1.15.2"
 "yq" = "v4.44.3"
 
 # lint

--- a/src/package_io/registry.star
+++ b/src/package_io/registry.star
@@ -49,14 +49,14 @@ OP_BLOCKSCOUT_VERIFIER = "op-blockscout-verifier"
 
 _DEFAULT_IMAGES = {
     # EL images
-    OP_GETH: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101604.0",
-    OP_RETH: "ghcr.io/paradigmxyz/op-reth:v1.6.0",
+    OP_GETH: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101609.1",
+    OP_RETH: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-reth:v1.11.0",
     OP_ERIGON: "testinprod/op-erigon:v2.61.3-0.9.5",
     OP_NETHERMIND: "nethermind/nethermind:1.32.4",
     OP_BESU: "ghcr.io/optimism-java/op-besu:v0.2.2",
     OP_RBUILDER: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-rbuilder:sha-0ec0644",
     # CL images
-    OP_NODE: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.16.4",
+    OP_NODE: "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.16.7",
     KONA_NODE: "ghcr.io/op-rs/kona/kona-node:1.0.0-rc.1",
     HILDR: "ghcr.io/optimism-java/hildr:v0.4.5",
     # Batching

--- a/test/l2/participant/input_parser_test.star
+++ b/test/l2/participant/input_parser_test.star
@@ -78,7 +78,7 @@ def test_l2_participant_input_parser_defaults(plan):
                 sequencer="node0",
                 cl=struct(
                     type="op-node",
-                    image="us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.16.4",
+                    image="us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.16.7",
                     name="node0",
                     service_name="op-cl-1-op-node-op-geth-my-l2",
                     labels={
@@ -101,7 +101,7 @@ def test_l2_participant_input_parser_defaults(plan):
                 cl_builder=struct(
                     name="node0",
                     type="op-node",
-                    image="us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.16.4",
+                    image="us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.16.7",
                     service_name="op-clbuilder-1-op-node-op-geth-my-l2",
                     labels={
                         "op.kind": "clbuilder",
@@ -124,7 +124,7 @@ def test_l2_participant_input_parser_defaults(plan):
                     name="node0",
                     type="op-geth",
                     service_name="op-el-1-op-geth-op-node-my-l2",
-                    image="us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101604.0",
+                    image="us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101609.1",
                     labels={
                         "op.kind": "el",
                         "op.network.id": "1000",
@@ -148,7 +148,7 @@ def test_l2_participant_input_parser_defaults(plan):
                 el_builder=struct(
                     name="node0",
                     type="op-geth",
-                    image="us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101604.0",
+                    image="us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101609.1",
                     service_name="op-elbuilder-1-op-geth-op-node-my-l2",
                     labels={
                         "op.kind": "elbuilder",
@@ -184,7 +184,7 @@ def test_l2_participant_input_parser_defaults(plan):
                 cl=struct(
                     name="node1",
                     type="op-node",
-                    image="us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.16.4",
+                    image="us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.16.7",
                     service_name="op-cl-2-op-node-op-geth-my-l2",
                     labels={
                         "op.kind": "cl",
@@ -206,7 +206,7 @@ def test_l2_participant_input_parser_defaults(plan):
                 cl_builder=struct(
                     name="node1",
                     type="op-node",
-                    image="us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.16.4",
+                    image="us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.16.7",
                     service_name="op-clbuilder-2-op-node-op-geth-my-l2",
                     labels={
                         "op.kind": "clbuilder",
@@ -228,7 +228,7 @@ def test_l2_participant_input_parser_defaults(plan):
                 el=struct(
                     name="node1",
                     type="op-geth",
-                    image="us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101604.0",
+                    image="us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101609.1",
                     service_name="op-el-2-op-geth-op-node-my-l2",
                     labels={
                         "op.kind": "el",
@@ -253,7 +253,7 @@ def test_l2_participant_input_parser_defaults(plan):
                 el_builder=struct(
                     name="node1",
                     type="op-geth",
-                    image="us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101604.0",
+                    image="us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101609.1",
                     service_name="op-elbuilder-2-op-geth-op-node-my-l2",
                     labels={
                         "op.kind": "elbuilder",

--- a/test/package_io/registry_test.star
+++ b/test/package_io/registry_test.star
@@ -1,7 +1,7 @@
 registry = import_module("/src/package_io/registry.star")
 
-DEFAULT_OP_GETH = "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101604.0"
-DEFAULT_OP_NODE = "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.16.4"
+DEFAULT_OP_GETH = "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-geth:v1.101609.1"
+DEFAULT_OP_NODE = "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.16.7"
 
 
 def test_registry_default_images(_plan):


### PR DESCRIPTION
## Description

- Bump versions
- Switch from op-geth to op-reth in `custom.yaml`

## Test

```bash
Check 77/100
Got blocks for op-el-1-op-reth-op-node-001: latest=199, safe=183, finalized=171
Target block 50 reached for all block types (latest, safe, finalized) for op-el-1-op-reth-op-node-001
All target blocks have been reached for all block types (latest, safe, finalized). Exiting.
```

For reference: https://github.com/agglayer/optimism-package/actions/runs/22683186053/job/65759658579?pr=34